### PR TITLE
Use PSR-11 container

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -2,8 +2,8 @@
 
 namespace TheCodingMachine\ServiceProvider;
 
-use Interop\Container\ContainerInterface;
 use Interop\Container\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
 use TheCodingMachine\Discovery\DiscoveryInterface as Discovery;
 
 /**

--- a/src/RegistryInterface.php
+++ b/src/RegistryInterface.php
@@ -1,8 +1,7 @@
 <?php
 namespace TheCodingMachine\ServiceProvider;
 
-use Interop\Container\ContainerInterface;
-
+use Psr\Container\ContainerInterface;
 
 /**
  * A class that holds the list of service providers of a project.


### PR DESCRIPTION
The dependency to `container-interop/service-provider:^0.4` changes the
signature of the container, from the container-interop container to
PSR-11 container.